### PR TITLE
Enable health checks for ui & server

### DIFF
--- a/roles/provision-data-sync-apb/tasks/provision-sync-server.yml
+++ b/roles/provision-data-sync-apb/tasks/provision-sync-server.yml
@@ -51,6 +51,8 @@
 
 - name: Create data-sync-server https route
   openshift_v1_route:
+    annotations:
+      console.alpha.openshift.io/overview-app-route: 'true'
     name: data-sync-server
     namespace: '{{ namespace }}'
     labels:

--- a/roles/provision-data-sync-apb/tasks/provision-sync-server.yml
+++ b/roles/provision-data-sync-apb/tasks/provision-sync-server.yml
@@ -16,12 +16,12 @@
     - name: data-sync-server
       image: '{{ sync_server_image }}:{{ sync_server_version }}'
       imagePullPolicy: IfNotPresent
-      # readinessProbe:
-      #   httpGet:
-      #     path: /healthz
-      #     port: "{{ sync_server_port }}"
-      #   initialDelaySeconds: 15
-      #   timeoutSeconds: 1
+      readinessProbe:
+        httpGet:
+          path: /healthz
+          port: "{{ sync_server_port }}"
+        initialDelaySeconds: 15
+        timeoutSeconds: 1
       env:
       - name: POSTGRES_HOST
         value: '{{ postgres_service_name }}'
@@ -88,13 +88,3 @@
   until: aerogear_app_data_sync_server_result.stdout.find("1") != -1
   retries: 30
   delay: 10
-
-  # - name: Wait for app-data-sync-server health endpoint to report healthy
-  # uri:
-  #   url: https://{{ data_sync_server_route.route.spec.host }}/healthz
-  #   validate_certs: no
-  #   status_code: 200
-  # register: app_data-sync-server_health
-  # until: app_data-sync-server_health.status == 200
-  # retries: 30
-  # delay: 10

--- a/roles/provision-data-sync-apb/tasks/provision-sync-ui.yml
+++ b/roles/provision-data-sync-apb/tasks/provision-sync-ui.yml
@@ -17,12 +17,12 @@
     - name: data-sync-ui
       image: '{{ sync_ui_image }}:{{ sync_ui_version }}'
       imagePullPolicy: IfNotPresent
-      # readinessProbe:
-      #   httpGet:
-      #     path: /healthz
-      #     port: "{{ sync_ui_port }}"
-      #   initialDelaySeconds: 15
-      #   timeoutSeconds: 1
+      readinessProbe:
+        httpGet:
+          path: /healthz
+          port: "{{ sync_ui_port }}"
+        initialDelaySeconds: 15
+        timeoutSeconds: 1
       env:
       - name: POSTGRES_HOST
         value: '{{ postgres_service_name }}'
@@ -85,13 +85,3 @@
   until: aerogear_app_data_sync_ui_result.stdout.find("2") != -1
   retries: 30
   delay: 10
-
-  # - name: Wait for app-data-sync-ui health endpoint to report healthy
-  # uri:
-  #   url: https://{{ data_sync_ui_route.route.spec.host }}/healthz
-  #   validate_certs: no
-  #   status_code: 200
-  # register: app_data-sync-ui_health
-  # until: app_data-sync-ui_health.status == 200
-  # retries: 30
-  # delay: 10


### PR DESCRIPTION
### Notes/questions
* Removed [this task](https://github.com/aerogearcatalog/data-sync-apb/pull/5/files#diff-5800809279c9405530d19a7085f96294L92) (also from sync-ui), since we're testing hostname accessibility in [provision test](https://github.com/aerogearcatalog/data-sync-apb/blob/master/roles/test-data-sync-apb/tasks/provision.yml)
* What it [this variable](https://github.com/aerogearcatalog/data-sync-apb/blob/master/roles/provision-data-sync-apb/tasks/provision-sync-server.yml#L34) for? Will it have any use in a future?