### PR TITLE
Added postgres_port env var to Sync & UI DCs

### DIFF
--- a/roles/provision-data-sync-apb/tasks/provision-sync-server.yml
+++ b/roles/provision-data-sync-apb/tasks/provision-sync-server.yml
@@ -24,7 +24,9 @@
         timeoutSeconds: 1
       env:
       - name: POSTGRES_HOST
-        value: '{{ postgres_service_name }}'
+        value: "{{ postgres_service_name }}"
+      - name: POSTGRES_PORT
+        value: "{{ postgres_port|string }}"
       - name: POSTGRES_PASSWORD
         value: "{{ postgres_password}}"
       - name: POSTGRES_USERNAME

--- a/roles/provision-data-sync-apb/tasks/provision-sync-ui.yml
+++ b/roles/provision-data-sync-apb/tasks/provision-sync-ui.yml
@@ -25,7 +25,9 @@
         timeoutSeconds: 1
       env:
       - name: POSTGRES_HOST
-        value: '{{ postgres_service_name }}'
+        value: "{{ postgres_service_name }}"
+      - name: POSTGRES_PORT
+        value: "{{ postgres_port|string }}"
       - name: POSTGRES_PASSWORD
         value: "{{ postgres_password}}"
       - name: POSTGRES_USERNAME


### PR DESCRIPTION
### Motivation
Error in **Data Sync Server** pod when provisioning:
```
> data-sync-server@1.0.0 start /opt/app-root/src
> node ./index.js
{"level":30,"time":1532701708630,"msg":"Using default schemaListener since SCHEMA_LISTENER_CONFIG environment variable is not defined","pid":19,"hostname":"data-sync-server-1-hfcsr","v":1}
unhandled rejection: RangeError: "port" option should be >= 0 and < 65536: NaN
```