### PR TITLE
Imagepullpolicy -> always pull new image

### DIFF
--- a/roles/provision-data-sync-apb/tasks/provision-sync-server.yml
+++ b/roles/provision-data-sync-apb/tasks/provision-sync-server.yml
@@ -15,7 +15,7 @@
     containers:
     - name: data-sync-server
       image: '{{ sync_server_image }}:{{ sync_server_version }}'
-      imagePullPolicy: IfNotPresent
+      imagePullPolicy: Always
       readinessProbe:
         httpGet:
           path: /healthz

--- a/roles/provision-data-sync-apb/tasks/provision-sync-ui.yml
+++ b/roles/provision-data-sync-apb/tasks/provision-sync-ui.yml
@@ -16,7 +16,7 @@
     containers:
     - name: data-sync-ui
       image: '{{ sync_ui_image }}:{{ sync_ui_version }}'
-      imagePullPolicy: IfNotPresent
+      imagePullPolicy: Always
       readinessProbe:
         httpGet:
           path: /healthz


### PR DESCRIPTION
@cfoskin @pb82 this change probably doesn't make sense for Postgres image since it has image name + version specified