### PR TITLE
Use pod autodiscovery for metrics

### DIFF
--- a/roles/provision-data-sync-apb/tasks/provision-sync-server.yml
+++ b/roles/provision-data-sync-apb/tasks/provision-sync-server.yml
@@ -18,6 +18,9 @@
     - name: data-sync-server
       image: '{{ sync_server_image }}:{{ sync_server_version }}'
       imagePullPolicy: Always
+      ports:
+       - containerPort: 8000
+         protocol: TCP
       readinessProbe:
         httpGet:
           path: /healthz

--- a/roles/provision-data-sync-apb/tasks/provision-sync-server.yml
+++ b/roles/provision-data-sync-apb/tasks/provision-sync-server.yml
@@ -12,6 +12,8 @@
     spec_template_metadata_labels:
       app: data-sync
       service: data-sync-server
+    spec_template_metadata_annotations:
+      org.aerogear.metrics/plain_endpoint: /metrics
     containers:
     - name: data-sync-server
       image: '{{ sync_server_image }}:{{ sync_server_version }}'
@@ -40,8 +42,6 @@
   k8s_v1_service:
     name: data-sync-server
     namespace: '{{ namespace }}'
-    annotations:
-      org.aerogear.metrics/plain_endpoint: "/metrics"
     labels:
       app: data-sync
       service: data-sync-server

--- a/roles/provision-data-sync-apb/tasks/provision-sync-ui.yml
+++ b/roles/provision-data-sync-apb/tasks/provision-sync-ui.yml
@@ -54,8 +54,6 @@
   k8s_v1_service:
     name: data-sync-ui
     namespace: '{{ namespace }}'
-    annotations:
-      org.aerogear.metrics/plain_endpoint: "/metrics"
     labels:
       app: data-sync
       service: data-sync-ui

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@
 # Global constants
 sync_secret_name: "sync"
 proxy_serviceaccount_name: "data-sync-oauth-proxy"
-postgres_claim_name: "postgres-claim"
+postgres_claim_name: "postgres-claim-sync"
 postgres_service_name: "postgres-data-sync"
 sync_server_service_name: "data-sync-server"
 sync_ui_service_name: "data-sync-ui"


### PR DESCRIPTION
How to verify:

- Provision https://github.com/aerogearcatalog/metrics-apb/pull/77
- Provision this PR
- Check the pod logs for data sync server pod. You should see request logs to `/metrics`.
- Scale up. Check the other pods' logs for the same request log entries.

You can see these in Prometheus:

```

up{app="data-sync",deployment="data-sync-server-1",deploymentconfig="data-sync-server",instance="172.17.0.19:8000",job="mcp-plain-pods",kubernetes_namespace="asd",kubernetes_pod_name="data-sync-server-1-bl6xr",service="data-sync-server"} | 1
-- | --
up{app="data-sync",deployment="data-sync-server-1",deploymentconfig="data-sync-server",instance="172.17.0.7:8000",job="mcp-plain-pods",kubernetes_namespace="asd",kubernetes_pod_name="data-sync-server-1-csw8x",service="data-sync-server"}

````

and aggregate stuff using `service=data-sync-server`.