### PR TITLE
Additional changes to Data Sync Dashboard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,9 @@ CiAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgCg=="
 
 
 
-COPY playbooks /opt/apb/actions
+COPY playbooks /opt/apb/project
 COPY roles /opt/ansible/roles
 COPY vars /opt/ansible/vars
-RUN ansible-galaxy install -r /opt/apb/actions/requirements.yml -p /opt/ansible/roles
+RUN ansible-galaxy install -r /opt/apb/project/requirements.yml -p /opt/ansible/roles
 RUN chmod -R g=u /opt/{ansible,apb}
 USER apb

--- a/roles/deprovision-data-sync-apb/tasks/main.yml
+++ b/roles/deprovision-data-sync-apb/tasks/main.yml
@@ -2,7 +2,7 @@
   shell: oc delete all -l app=data-sync -n '{{ namespace }}'
 
 - k8s_v1_config_map:
-    name: 'data-sync'
+    name: '{{ sync_configmap_name }}'
     namespace: '{{ namespace }}'
     state: absent
 

--- a/roles/provision-data-sync-apb/files/data-sync-dashboard.json
+++ b/roles/provision-data-sync-apb/files/data-sync-dashboard.json
@@ -172,7 +172,7 @@
       "targets": [
         {
           "alias": "",
-          "expr": "sum(nodejs_heap_size_total_bytes{service=\"data-sync-server\"} + nodejs_heap_size_used_bytes{service=\"data-sync-server\"})",
+          "expr": "sum(process_resident_memory_bytes{service=\"data-sync-server\"})",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,

--- a/roles/provision-data-sync-apb/files/data-sync-dashboard.json
+++ b/roles/provision-data-sync-apb/files/data-sync-dashboard.json
@@ -1,40 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "5.0.0-pre1"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "singlestat",
-      "name": "Singlestat",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -89,9 +53,9 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "decimals": 1,
-      "description": "Memory currently being used by Data Sync Server.",
+      "description": "Memory currently being used by Data Sync Server pods",
       "format": "bytes",
       "gauge": {
         "maxValue": 2067000000,
@@ -144,7 +108,7 @@
       "tableColumn": "Value",
       "targets": [
         {
-          "expr": "sum(nodejs_heap_size_total_bytes + nodejs_heap_size_used_bytes)",
+          "expr": "sum(process_resident_memory_bytes{service=\"data-sync-server\"})",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -172,7 +136,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 2,
       "gridPos": {
         "h": 7,
@@ -207,7 +171,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(nodejs_heap_size_total_bytes + nodejs_heap_size_used_bytes)",
+          "alias": "",
+          "expr": "sum(nodejs_heap_size_total_bytes{service=\"data-sync-server\"} + nodejs_heap_size_used_bytes{service=\"data-sync-server\"})",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -216,7 +181,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": "72h",
+      "timeFrom": null,
       "timeShift": null,
       "title": "Memory Usage In Time",
       "tooltip": {
@@ -261,7 +226,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "decimals": 1,
       "description": "CPU currently being used by Data Sync Server.",
       "format": "percent",
@@ -316,7 +281,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "rate(process_cpu_user_seconds_total[30s]) * 100",
+          "expr": "sum(rate(process_cpu_user_seconds_total{service=\"data-sync-server\"}[30s]) * 100)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -341,7 +306,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 2,
       "gridPos": {
         "h": 7,
@@ -376,7 +341,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(process_cpu_user_seconds_total[30s]) * 100",
+          "expr": "sum(rate(process_cpu_user_seconds_total{service=\"data-sync-server\"}[30s]) * 100)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -386,7 +351,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": "72h",
+      "timeFrom": null,
       "timeShift": null,
       "title": "CPU Usage In Time",
       "tooltip": {
@@ -424,10 +389,10 @@
     },
     {
       "aliasColors": {},
-      "bars": false,
+      "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "description": "Number of queries and mutations resolved in time.",
       "fill": 2,
       "gridPos": {
@@ -439,6 +404,7 @@
       "hideTimeOverride": false,
       "id": 24,
       "legend": {
+        "alignAsTable": false,
         "avg": false,
         "current": false,
         "max": false,
@@ -449,13 +415,13 @@
         "total": false,
         "values": false
       },
-      "lines": true,
+      "lines": false,
       "linewidth": 1,
       "links": [],
       "nullPointMode": "connected",
       "percentage": false,
       "pointradius": 5,
-      "points": false,
+      "points": true,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
@@ -463,7 +429,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "requests_resolved{operation_type=\"query\"}",
+          "expr": "sum(requests_resolved{operation_type=\"query\", service=\"data-sync-server\"})",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -472,8 +438,9 @@
           "refId": "A"
         },
         {
-          "expr": "requests_resolved{operation_type=\"mutation\"}",
+          "expr": "sum(requests_resolved{operation_type=\"mutation\", service=\"data-sync-server\"})",
           "format": "time_series",
+          "instant": false,
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Mutations",
@@ -481,11 +448,11 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": "72h",
+      "timeFrom": null,
       "timeShift": null,
       "title": "Queries/Mutations Resolved",
       "tooltip": {
-        "shared": true,
+        "shared": false,
         "sort": 0,
         "value_type": "individual"
       },
@@ -519,10 +486,10 @@
     },
     {
       "aliasColors": {},
-      "bars": false,
+      "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "description": "Resolver response time in milliseconds",
       "fill": 1,
       "gridPos": {
@@ -534,53 +501,55 @@
       "hideTimeOverride": false,
       "id": 20,
       "legend": {
-        "avg": false,
+        "alignAsTable": true,
+        "avg": true,
         "current": false,
         "max": false,
         "min": false,
         "rightSide": true,
         "show": true,
-        "sideWidth": 70,
+        "sideWidth": 150,
         "total": false,
-        "values": false
+        "values": true
       },
-      "lines": true,
+      "lines": false,
       "linewidth": 1,
       "links": [],
       "nullPointMode": "connected",
       "percentage": false,
       "pointradius": 5,
-      "points": false,
+      "points": true,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
-      "steppedLine": true,
+      "steppedLine": false,
       "targets": [
         {
-          "expr": "resolver_timing_ms{operation_type=\"query\"}",
+          "expr": "avg(resolver_timing_ms_sum{operation_type=\"query\", service=\"data-sync-server\"} / resolver_timing_ms_count{operation_type=\"query\", service=\"data-sync-server\"})",
           "format": "time_series",
           "instant": false,
-          "interval": "",
+          "interval": "1s",
           "intervalFactor": 1,
           "legendFormat": "Query",
           "refId": "A"
         },
         {
-          "expr": "resolver_timing_ms{operation_type=\"mutation\"}",
+          "expr": "avg(resolver_timing_ms_sum{operation_type=\"mutation\", service=\"data-sync-server\"} / resolver_timing_ms_count{operation_type=\"mutation\", service=\"data-sync-server\"})",
           "format": "time_series",
           "instant": false,
+          "interval": "1s",
           "intervalFactor": 1,
           "legendFormat": "Mutation",
           "refId": "B"
         }
       ],
       "thresholds": [],
-      "timeFrom": "72h",
+      "timeFrom": null,
       "timeShift": null,
       "title": "Resolver Timings",
       "tooltip": {
-        "shared": true,
+        "shared": false,
         "sort": 0,
         "value_type": "individual"
       },
@@ -622,8 +591,8 @@
     "list": []
   },
   "time": {
-    "from": "now-15m",
-    "to": "now"
+    "from": "now/d",
+    "to": "now/d"
   },
   "timepicker": {
     "refresh_intervals": [

--- a/roles/provision-data-sync-apb/files/data-sync-dashboard.json
+++ b/roles/provision-data-sync-apb/files/data-sync-dashboard.json
@@ -137,23 +137,24 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "fill": 2,
+      "fill": 0,
       "gridPos": {
         "h": 7,
-        "w": 13,
+        "w": 20,
         "x": 4,
         "y": 2
       },
       "hideTimeOverride": false,
       "id": 16,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
         "max": false,
         "min": false,
         "rightSide": true,
         "show": true,
-        "sideWidth": 70,
+        "sideWidth": 150,
         "total": false,
         "values": false
       },
@@ -165,19 +166,32 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "Average of all pods",
+          "fill": 2,
+          "linewidth": 3
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
           "alias": "",
-          "expr": "sum(process_resident_memory_bytes{service=\"data-sync-server\"})",
+          "expr": "avg(process_resident_memory_bytes{service=\"data-sync-server\"})",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "Memory Usage",
+          "legendFormat": "Average of all pods",
           "refId": "A"
+        },
+        {
+          "expr": "process_resident_memory_bytes{service=\"data-sync-server\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ kubernetes_pod_name }}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -307,23 +321,24 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "fill": 2,
+      "fill": 0,
       "gridPos": {
         "h": 7,
-        "w": 13,
+        "w": 20,
         "x": 4,
         "y": 9
       },
       "hideTimeOverride": false,
       "id": 19,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
         "max": false,
         "min": false,
         "rightSide": true,
         "show": true,
-        "sideWidth": 70,
+        "sideWidth": 150,
         "total": false,
         "values": false
       },
@@ -335,19 +350,32 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "Average of all pods",
+          "fill": 2,
+          "linewidth": 3
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(process_cpu_user_seconds_total{service=\"data-sync-server\"}[30s]) * 100)",
+          "expr": "avg(rate(process_cpu_user_seconds_total{service=\"data-sync-server\"}[30s]) * 100)",
           "format": "time_series",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "CPU  Usage",
+          "legendFormat": "Average of all pods",
           "refId": "A"
+        },
+        {
+          "expr": "rate(process_cpu_user_seconds_total{service=\"data-sync-server\"}[30s]) * 100",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ kubernetes_pod_name }}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -397,7 +425,7 @@
       "fill": 2,
       "gridPos": {
         "h": 6,
-        "w": 8,
+        "w": 9,
         "x": 0,
         "y": 16
       },
@@ -494,8 +522,8 @@
       "fill": 1,
       "gridPos": {
         "h": 6,
-        "w": 9,
-        "x": 8,
+        "w": 7,
+        "x": 9,
         "y": 16
       },
       "hideTimeOverride": false,
@@ -580,6 +608,101 @@
           "show": false
         }
       ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Server response time in milliseconds",
+      "fill": 2,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "hideTimeOverride": false,
+      "id": 26,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 120,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(server_response_ms_sum{request_type=\"POST\", service=\"data-sync-server\"} / server_response_ms_count{request_type=\"POST\", service=\"data-sync-server\"})",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "POST",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(server_response_ms_sum{request_type=\"GET\", service=\"data-sync-server\"} / server_response_ms_count{request_type=\"GET\", service=\"data-sync-server\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "GET",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server response time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ]
     }
   ],
   "schemaVersion": 16,
@@ -592,7 +715,7 @@
   },
   "time": {
     "from": "now/d",
-    "to": "now/d"
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [

--- a/roles/provision-data-sync-apb/templates/client-configmap-test.yml.j2
+++ b/roles/provision-data-sync-apb/templates/client-configmap-test.yml.j2
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: sync
+  name: {{ sync_configmap_name }}
   namespace: {{ namespace }}
   labels:
     mobile: enabled

--- a/roles/provision-data-sync-apb/templates/client-configmap.yml.j2
+++ b/roles/provision-data-sync-apb/templates/client-configmap.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: sync
+  name: {{ sync_configmap_name }}
   namespace: {{ namespace }}
   labels:
     mobile: enabled

--- a/roles/test-data-sync-apb/tasks/deprovision.yml
+++ b/roles/test-data-sync-apb/tasks/deprovision.yml
@@ -60,7 +60,7 @@
     - '"not found" not in result.stdout'
   until: '"not found" in result.stdout'
   with_items:
-    - data-sync
+    - '{{ sync_configmap_name }}'
 
 - name: "Test|Check that all persistent volume claims have been removed"
   shell: oc get pvc --namespace={{ namespace }} {{ item }} 2>&1

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,6 +2,7 @@
 
 # Global constants
 sync_secret_name: "sync"
+sync_configmap_name: "sync"
 proxy_serviceaccount_name: "data-sync-oauth-proxy"
 postgres_claim_name: "postgres-claim-sync"
 postgres_service_name: "postgres-data-sync"


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-7652

## What was changed
* addressed warning from provisioning pod: `DEPRECATED: APB playbooks should be stored at /opt/apb/project`
* fixed removing data sync configmap (it was using incorrect name and configmap still remained in the project after deprovisioning)
* few changes to graphs in Data Sync Dashboard

## Verification
* This APB was temporarily provisioned here (should be available during review time of this PR): https://grafana-metrics.apb-testing.skunkhenry.com/dashboard/db/data-sync?orgId=1&from=now%2Fd&to=now - check that out