### PR TITLE
feat: use imageStreams for UI & Server images

### DIFF
--- a/roles/provision-data-sync-apb/tasks/provision-sync-server.yml
+++ b/roles/provision-data-sync-apb/tasks/provision-sync-server.yml
@@ -28,6 +28,20 @@
     tls_insecure_edge_termination_policy: Redirect
   register: data_sync_server_route
 
+- name: "Create ImageStream with tag {{ sync_server_version }} for Data Sync Server image"
+  openshift_v1_image_stream:
+    name: "data-sync-server"
+    namespace: "{{ namespace }}"
+    labels:
+      app: "data-sync"
+    lookup_policy_local: False
+    tags:
+      - name: "{{ sync_server_version }}"
+        from:
+          kind: DockerImage
+          name: "{{ sync_server_image }}:{{ sync_server_version }}"
+        importPolicy:
+          scheduled: true
 
 - name: Create data-sync-server deployment config
   openshift_v1_deployment_config:
@@ -45,6 +59,17 @@
       service: data-sync-server
     spec_template_metadata_annotations:
       org.aerogear.metrics/plain_endpoint: /metrics
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - "data-sync-server"
+        from:
+          kind: ImageStreamTag
+          name: "data-sync-server:{{ sync_server_version }}"
+          namespace: "{{ namespace }}"
+      type: ImageChange
+    - type: ConfigChange
     containers:
     - name: data-sync-server
       image: '{{ sync_server_image }}:{{ sync_server_version }}'

--- a/roles/provision-data-sync-apb/tasks/provision-sync-ui.yml
+++ b/roles/provision-data-sync-apb/tasks/provision-sync-ui.yml
@@ -1,3 +1,18 @@
+- name: "Create ImageStream with tag {{ sync_server_version }} for Data Sync UI image"
+  openshift_v1_image_stream:
+    name: "data-sync-ui"
+    namespace: "{{ namespace }}"
+    labels:
+      app: "data-sync"
+    lookup_policy_local: False
+    tags:
+      - name: "{{ sync_server_version }}"
+        from:
+          kind: DockerImage
+          name: "{{ sync_ui_image }}:{{ sync_server_version }}"
+        importPolicy:
+          scheduled: true
+
 - name: Create data-sync-ui deployment config
   openshift_v1_deployment_config:
     name: data-sync-ui
@@ -13,6 +28,17 @@
       app: data-sync
       service: data-sync-ui
     spec_template_spec_service_account_name: '{{ proxy_serviceaccount_name }}'
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - "data-sync-ui"
+        from:
+          kind: ImageStreamTag
+          name: "data-sync-ui:{{ sync_server_version }}"
+          namespace: "{{ namespace }}"
+      type: ImageChange
+    - type: ConfigChange
     containers:
     - name: data-sync-ui
       image: '{{ sync_ui_image }}:{{ sync_ui_version }}'


### PR DESCRIPTION
### Motivation
https://issues.jboss.org/browse/AEROGEAR-7935 && https://github.com/aerogearcatalog/data-sync-apb/issues/22

### How does it work
* https://github.com/aerogearcatalog/data-sync-apb/issues/22#issuecomment-421249703

### How to verify this
Verification is a bit complicated since you first need to provision APB from this branch and next push some changes to `aerogear/data-sync-server:master` or `aerogear/data-sync-ui:master`images on dockerhub (you need to have write permissions in the org).
I tested this by changing the org name [here](https://github.com/aerogearcatalog/data-sync-apb/blob/master/roles/provision-data-sync-apb/defaults/main.yml#L2) to my own org (username), provisioned APB and pushed new image to those repos.

Currently changes are deployed [here](https://apb-testing.skunkhenry.com:8443/console/project/datasync-test/overview) (requires RH VPN connection)